### PR TITLE
Bold nick in CTCP ACTION when relayed to discord.

### DIFF
--- a/pkg/irc.go
+++ b/pkg/irc.go
@@ -147,7 +147,7 @@ func onIrcCtcpAction(e *ircE.Event) {
 	}
 
 	msg := ircFormat.ReplaceAllString(e.Message(), "")
-	sendDiscord("\\* " + e.Nick + " *" + messageWithMention(msg) + "*")
+	sendDiscord("\\* **" + e.Nick + "** *" + messageWithMention(msg) + "*")
 }
 
 // JOIN callback


### PR DESCRIPTION
Just to be more consistent with the other nick outputs.